### PR TITLE
Fix generator converting null values to undefined for non-required properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,4 +1,4 @@
-import { exists, mapValues } from '../runtime';
+import { exists, isOptionalKey, mapValues } from '../runtime';
 {{#hasImports}}
 import {
     {{#imports}}
@@ -38,7 +38,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 {{/discriminator.mappedModels}}
     }
 {{/discriminator}}
-    return {
+    const rv = {
         {{#parent}}...{{{parent}}}FromJSONTyped(json, ignoreDiscriminator),{{/parent}}
         {{#additionalPropertiesType}}
             ...json,
@@ -46,42 +46,49 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#vars}}
         {{#isPrimitiveType}}
         {{#isDate}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDate}}
         {{#isDateTime}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateTime}}
         {{^isDate}}
         {{^isDateTime}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': json['{{baseName}}'],
         {{/isDateTime}}
         {{/isDate}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? json['{{baseName}}'] : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}
         {{/isPrimitiveType}}
         {{/vars}}
     };
+    Object.keys(rv).forEach(_key => {
+        const key = _key as keyof {{classname}};
+        if (isOptionalKey(key, rv) && rv[key] === undefined) {
+            delete rv[key];
+        }
+    });
+    return rv;
     {{/hasVars}}
     {{^hasVars}}
     return json;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -206,6 +206,14 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
+type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+type RequiredKeys<T> = Exclude<KeysOfType<T, Exclude<T[keyof T], undefined>>, undefined>
+export type OptionalKeys<T> = Omit<T, RequiredKeys<T>>
+
+export function isOptionalKey<T>(key: keyof T, obj: T): key is keyof OptionalKeys<T> {
+    return obj[key] === undefined;
+}
+
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map((key) => {


### PR DESCRIPTION
Fixes a few issues:
- Any non-required property that was returned as `null` by the API was being converted into `undefined` once parsed into a Javascript object
- Additionally, any non-required property not present in the API response had a key included in the returned object but the value is undefined.

Having objects with string keys and undefined values does not play well with React props -- we really want this to be null if they were returned as null or not present in the Javascript object if they were not present in the API response.

Have built a Docker image of this branch by doing:

```
docker build --platform linux/amd64 -t openapi-generator-cli:5.1.1-jtbeach .
docker tag openapi-generator-cli:5.1.1-jtbeach ingenovishealth/openapi-generator-cli:5.1.1-jtbeach
docker push ingenovishealth/openapi-generator-cli:5.1.1-jtbeach
```

This has been uploaded to https://hub.docker.com/repository/docker/ingenovishealth/openapi-generator-cli